### PR TITLE
Allow Lets Encrypt to issue certificates

### DIFF
--- a/dns/route53.tf
+++ b/dns/route53.tf
@@ -5,6 +5,7 @@ resource "aws_route53_record" "root_caa" {
   ttl     = 300
 
   records = [
+    "0 issue \"letsencrypt.org\"",
     "0 issuewild \"amazontrust.com\"",
     "0 issuewild \"awstrust.com\"",
     "0 issuewild \"amazonaws.com\"",


### PR DESCRIPTION
We use Let's Encrypt to issue certificates for our domains, via Heroku.